### PR TITLE
Remove RubyGems Push Protection

### DIFF
--- a/rest-client-jogger.gemspec
+++ b/rest-client-jogger.gemspec
@@ -14,14 +14,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/amaabca/rest-client-jogger"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = ""
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
:elephant:

* As this is a public gem, we want it published on RubyGems.
* Remove the restriction in the gemspec.