### PR TITLE
Fix JSON Filter Regular Expression

### DIFF
--- a/lib/rest_client/jogger/filters/json.rb
+++ b/lib/rest_client/jogger/filters/json.rb
@@ -6,7 +6,7 @@ module RestClient
       private
 
         def filter_data(filter)
-          data.gsub! /"(#{filter})": ?"(.*[^\"])"/, "\"#{filter}\": \"#{filter_replacement}\""
+          data.gsub! /"#{filter}":\s*"[^"]*"/, %{"#{filter}": "#{filter_replacement}"}
         end
       end
     end

--- a/lib/rest_client/jogger/filters/xml.rb
+++ b/lib/rest_client/jogger/filters/xml.rb
@@ -6,7 +6,7 @@ module RestClient
       private
 
         def filter_data(filter)
-          data.gsub! /<#{filter}>(.*)<\/#{filter}>/, "<#{filter}>#{filter_replacement}</#{filter}>"
+          data.gsub! /<#{filter}>(.*)<\/#{filter}>/, %{<#{filter}>#{filter_replacement}</#{filter}>}
         end
       end
     end

--- a/lib/rest_client/jogger/version.rb
+++ b/lib/rest_client/jogger/version.rb
@@ -1,5 +1,5 @@
 module RestClient
   module Jogger
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.3.3'.freeze
   end
 end


### PR DESCRIPTION
* There was a bug with our previous JSON regex. There were cases
  where we would truncate parts of a payload as soon as an attribute was
  filtered.

E.g. (previously)

Before Filter
{ "super": { "secret": { "password": "12345" } }, "data": "123" }

After Filter

{ "super": { "secret": { "password": "[FILTERED]" } }

* Updated the JSON filter regex to correctly match whitespace and single
  line/multi-line JSON payloads. It should also generate a correct JSON
  object when filtered now (previously it may have generated invalid
  JSON).