### PR TITLE
Remove authorization header from logged requests

### DIFF
--- a/lib/rest_client/core_ext/logged_request.rb
+++ b/lib/rest_client/core_ext/logged_request.rb
@@ -18,7 +18,7 @@ module LoggedRequest
     time = (Time.now - started).round(2)
     content_type = content_type_from_headers(opts[:headers])
     payload = filter(content_type).new(data: opts[:payload]).filter
-    opts[:headers].except!(:authorization) if opts[:headers]
+    opts[:headers].reject! { |k, _| k.to_s.casecmp('authorization').zero? } if opts[:headers]
     params = opts.except(:user, :password, :payload).merge(payload: payload)
     ActiveSupport::Notifications.instrument PATTERN,
       log_data(params, response, exception, time)

--- a/lib/rest_client/core_ext/logged_request.rb
+++ b/lib/rest_client/core_ext/logged_request.rb
@@ -18,6 +18,7 @@ module LoggedRequest
     time = (Time.now - started).round(2)
     content_type = content_type_from_headers(opts[:headers])
     payload = filter(content_type).new(data: opts[:payload]).filter
+    opts[:headers].except!(:authorization) if opts[:headers]
     params = opts.except(:user, :password, :payload).merge(payload: payload)
     ActiveSupport::Notifications.instrument PATTERN,
       log_data(params, response, exception, time)

--- a/lib/rest_client/jogger/version.rb
+++ b/lib/rest_client/jogger/version.rb
@@ -1,5 +1,5 @@
 module RestClient
   module Jogger
-    VERSION = '0.3.3'.freeze
+    VERSION = '0.3.4'.freeze
   end
 end


### PR DESCRIPTION
🐘 
* We don't want to expose our bearer tokens in loggly
* Fix timeout test - open timeouts instead of read timeouts