### PR TITLE
Remove sensitive headers from response

### DIFF
--- a/lib/rest_client/core_ext/logged_request.rb
+++ b/lib/rest_client/core_ext/logged_request.rb
@@ -38,7 +38,7 @@ module LoggedRequest
     if response
       {
         code: response.code,
-        headers: response.headers,
+        headers: response.headers.reject { |k, _| k.to_s.casecmp('authorization').zero? },
         body: response.body.to_s.force_encoding('UTF-8')
       }
     end

--- a/spec/rest_client/core_ext/logged_request_spec.rb
+++ b/spec/rest_client/core_ext/logged_request_spec.rb
@@ -19,6 +19,7 @@ describe RestClient::Request do
       end
 
       context 'HTTP 200' do
+        let(:headers) { { authorization: 'some bearer token', accept: 'json' } }
         let(:status) { 200 }
         let(:subscription) do
           -> (payload) {
@@ -29,12 +30,12 @@ describe RestClient::Request do
         end
 
         before(:each) do
-          WebMock.stub_request(:any, url).to_return(body: response, status: status)
+          WebMock.stub_request(:any, url).to_return(body: response, status: status, headers: headers)
           RestClient::Request.logged_request(
             method: :get,
             payload: 'payload',
             url: url,
-            headers: { authorization: 'some bearer token', accept: 'json' }
+            headers: headers
           )
         end
 
@@ -44,6 +45,10 @@ describe RestClient::Request do
 
         it 'strips authorization header' do
           expect(@payload.last[:request][:headers]).to eq ({ accept: 'json' })
+        end
+
+        it 'strips authorization header in the responses' do
+          expect(@payload.last[:response][:headers]).to eq ({ accept: 'json' })
         end
       end
 


### PR DESCRIPTION
🐘 
* Because we are experiencing instances where the ESB is responding with
the same request including the headers for authorization. Added a filter
on the response to reject the headers with authorization.