### PR TITLE
Raise a Rollbar.warning instead of Rollbar.error

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-bundle install
+bundle install --path=vendor/bundle
 
 # Do any other automated setup that you need to do here

--- a/lib/rest_client/jogger/request_complete.rb
+++ b/lib/rest_client/jogger/request_complete.rb
@@ -17,7 +17,7 @@ module RestClient
         message = ::JSON.dump(payload.merge(event_name: name, event_id: id, timestamp: start))
         name =~ /error/ ? logger.error(message) : logger.debug(message)
       rescue StandardError => e
-        notifier.error e, payload: payload
+        notifier.warning e, payload: payload
       end
 
     end

--- a/lib/rest_client/jogger/version.rb
+++ b/lib/rest_client/jogger/version.rb
@@ -1,5 +1,5 @@
 module RestClient
   module Jogger
-    VERSION = '0.3.5'.freeze
+    VERSION = '0.3.6'.freeze
   end
 end

--- a/spec/rest_client/jogger/request_complete_spec.rb
+++ b/spec/rest_client/jogger/request_complete_spec.rb
@@ -43,7 +43,7 @@ describe RestClient::Jogger::RequestComplete do
     context "logger is invalid" do
       it "notifies" do
         completer.logger = {}
-        expect(completer.notifier).to receive :error
+        expect(completer.notifier).to receive :warning
         completer.call "rest_client.request", timestamp, timestamp, "9c122712f744339c29e7", payload
       end
     end


### PR DESCRIPTION
- Ran into this during an outage we received from 511 endpoints. Chatted
with @darkodosenovic, @jessedoyle, and @mvandenbeuken; if there are
outages on a system we are calling, the calling system should be doing
the alerting. Even in the case of the api.ama.ab.ca it should alert. In
the case of apim.ama.ab.ca and soa.ama.ab.ca we can rely on Loggly
alerts to go to the appropriate team

- TODO: we might have to update the Loggly alerts for api.ama.ab.ca to
go to Red team on-call when there are outages/errors, but Rollbar should
currently be handling this.

- Bumps version number: I beleive a [patch is semantically
correct](https://semver.org) but it seems like a significant change, so
perhaps we need to bump further?

See:
- https://github.com/amaabca/sentinel_web/pull/1325 for more information