### PR TITLE
VSTS-14842 - Logging Standards

### DIFF
--- a/lib/rest_client/jogger/filters/base.rb
+++ b/lib/rest_client/jogger/filters/base.rb
@@ -17,6 +17,11 @@ module RestClient
           end
         end
 
+        def initialize(opts = {})
+          super
+          self.data = data.dup
+        end
+
         def filter
           filters.each do |filter|
             filter_data filter

--- a/lib/rest_client/templates/request_logging_template.json.jbuilder
+++ b/lib/rest_client/templates/request_logging_template.json.jbuilder
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 json.url args[:url]
 json.method args[:method]
-json.verify_ssl verify_ssl
-json.headers args.fetch(:headers, {})
-json.body do
-  json.payload payload
-end
+json.verifySsl verify_ssl
+json.requestHeaders args.fetch(:headers, {})
+json.requestBody payload
 json.sourceIp ip_address
-json.details do
-  json.eventName LoggedRequest::REQUEST_PATTERN
-  json.eventId event_id
-  json.timeElapsed time_elapsed
-  json.openTimeout open_timeout
-  json.readTimeout read_timeout
-end
+json.eventName LoggedRequest::REQUEST_PATTERN
+json.eventId event_id
+json.timeElapsed time_elapsed
+json.openTimeout open_timeout
+json.readTimeout read_timeout
 json.timestamp timestamp.iso8601

--- a/lib/rest_client/templates/request_logging_template.json.jbuilder
+++ b/lib/rest_client/templates/request_logging_template.json.jbuilder
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+json.ignore_nil!
 json.url args[:url]
 json.method args[:method]
 json.verifySsl verify_ssl

--- a/lib/rest_client/templates/response_logging_template.json.jbuilder
+++ b/lib/rest_client/templates/response_logging_template.json.jbuilder
@@ -1,21 +1,17 @@
 # frozen_string_literal: true
 json.url args[:url]
 json.method args[:method]
-json.verify_ssl verify_ssl
-json.headers args.fetch(:headers, {})
+json.verifySsl verify_ssl
+json.requestHeaders args.fetch(:headers, {})
 json.responseHeaders args[:response].try(:headers)
-json.body do
-  json.request payload
-  json.payload args[:response].try(:body).to_s.force_encoding('UTF-8')
-end
+json.requestBody payload
+json.responseBody args[:response].try(:body).to_s.force_encoding('UTF-8')
 json.sourceIp ip_address
-json.details do
-  json.eventName LoggedRequest::RESPONSE_PATTERN
-  json.eventId event_id
-  json.timeElapsed time_elapsed
-  json.openTimeout open_timeout
-  json.readTimeout read_timeout
-end
+json.eventName LoggedRequest::RESPONSE_PATTERN
+json.eventId event_id
+json.timeElapsed time_elapsed
+json.openTimeout open_timeout
+json.readTimeout read_timeout
 json.code args[:response].try(:code)
 json.timestamp timestamp.iso8601
 json.exception args[:exception]

--- a/lib/rest_client/templates/response_logging_template.json.jbuilder
+++ b/lib/rest_client/templates/response_logging_template.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+json.ignore_nil!
+json.exception args[:exception]
 json.url args[:url]
 json.method args[:method]
 json.verifySsl verify_ssl
@@ -14,4 +16,3 @@ json.openTimeout open_timeout
 json.readTimeout read_timeout
 json.code args[:response].try(:code)
 json.timestamp timestamp.iso8601
-json.exception args[:exception]

--- a/spec/rest_client/jogger/filters/json_spec.rb
+++ b/spec/rest_client/jogger/filters/json_spec.rb
@@ -33,6 +33,11 @@ describe RestClient::Jogger::Filters::Json do
       it 'returns a string' do
         expect(filter).to be_a String
       end
+
+      it 'does not modify the original input' do
+        filter
+        expect(json).not_to include(replacement)
+      end
     end
 
     context 'with invalid json' do

--- a/spec/rest_client/jogger/filters/xml_spec.rb
+++ b/spec/rest_client/jogger/filters/xml_spec.rb
@@ -32,6 +32,11 @@ describe RestClient::Jogger::Filters::Xml do
       it 'returns a string' do
         expect(filter).to be_a String
       end
+
+      it 'does not modify the original input' do
+        filter
+        expect(xml).not_to include(replacement)
+      end
     end
 
     context 'with invalid xml' do


### PR DESCRIPTION
* Implement our ideal log format, that is not deeply nested
  so we are able to perform queries easily.

### Request Schema

```crystal
# Request Log Payload
# Legend:
#  Type? === nullable field (key may be omitted)
#  Type (format) === serialize type using format
#  ... === system generated fields
{
  url : String,
  method : String,
  verifySsl : String?,
  requestHeaders : Object {
    ESBTransactionGUID : String,
    ...
  },
  requestBody : String?,
  sourceIp : String,
  eventName : String,
  eventId : String,
  timeElapsed : Number,
  openTimeout : Number,
  readTimeout : Number,
  timestamp : String (ISO8601)
}
```

### Response Schema

```crystal
# Request Log Payload
# Legend:
#  Type? === nullable field (key may be omitted)
#  Type (format) === serialize type using format
#  ... === system generated fields
{
  url : String,
  method : String,
  verifySsl : String?,
  requestHeaders : Object {
    ESBTransactionGUID : String,
    ...
  },
  responseHeaders : Object?,
  requestBody : String?,
  responseBody : String?, 
  sourceIp : String,
  eventName : String,
  timeElapsed : Number,
  openTimeout : Number,
  readTimeout : Number,
  code : Number,
  exception : String?,
  timestamp : String (ISO8601)
}
```

### Example Request Payload
```json
{
  "url": "https://example.ama.ab.ca/services/MemberService",
  "method": "post",
  "verifySsl": null,
  "requestHeaders": {
    "accept": "application/json",
    "content_type": "application/json/mf",
    "ESBTransactionGUID": "7e6e12a6-bad5-4756-a7f9-112d3d31bc93"
  },
  "requestBody": "{\"json\":\"request\"}",
  "sourceIp": "12.34.56.78",
  "eventName": "rest_client.request",
  "eventId": "700b998bfa80467dfab0",
  "timeElapsed": 0.000075541,
  "openTimeout": 2,
  "readTimeout": 15,
  "timestamp": "2018-10-05T16:54:14+00:00"
}
```

### Example Response Payload

```json
{
  "url": "https://example.ama.ab.ca/services/MemberService",
  "method": "post",
  "verifySsl": null,
  "requestHeaders": {
    "accept": "application/json",
    "content_type": "application/json/mf",
    "ESBTransactionGUID": "7e6e12a6-bad5-4756-a7f9-112d3d31bc93"
  },
  "responseHeaders": {
    "content_type": "application/json/mf; charset=utf-8",
    "content_encoding": "gzip",
    "response_time_esb": "875.0",
    "server": "Microsoft-IIS/7.5",
    "vary": "Accept-Encoding",
    "x_powered_by": "ASP.NET",
    "date": "Fri, 05 Oct 2018 16:54:15 GMT",
    "transfer_encoding": "chunked",
    "strict_transport_security": "max-age=63072000 ; includeSubDomains"
  },
  "requestBody": "{\"json\":\"request\"}",
  "responseBody": "{\"json\":\"response\"}",
  "sourceIp": "12.34.56.78",
  "eventName": "rest_client.response",
  "eventId": "700b998bfa80467dfab0",
  "timeElapsed": 1.094640112,
  "openTimeout": 2,
  "readTimeout": 15,
  "code": 200,
  "timestamp": "2018-10-05T16:54:15+00:00",
  "exception": null
}
```

Loggly Example: https://ama.loggly.com/search#terms=%22rest_client.request%22%20OR%20%22rest_client.response%22&from=2018-10-05T16:11:24.306Z&until=2018-10-05T17:11:24.306Z&source_group=17378

SEE: https://amaabca.visualstudio.com/blue_tech_debt/_workitems/edit/14842