### PR TITLE
ADO 9566: Dependency Updates

### DIFF
--- a/lib/rest_client/jogger/version.rb
+++ b/lib/rest_client/jogger/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module RestClient
   module Jogger
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.2.1'.freeze
   end
 end

--- a/rest-client-jogger.gemspec
+++ b/rest-client-jogger.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'tilt-jbuilder'
 
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.2"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-json_expectations"
   spec.add_development_dependency "rest-client", "~> 2.0.0"


### PR DESCRIPTION
See: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/9566

* bump minimum rake dev dependency (CVE-2020-8130)