### PR TITLE
ADO-18933 - Ruby 2.7 Bugfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - '2.5'
+          - '2.6'
+          - '2.7'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Build and test with Rake
+        run: |
+          gem install bundler
+          echo 'bundle install'
+          bundle install --jobs 4 --retry 3
+          bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.0
-  - 2.2.1
-  - 2.2.2
-  - 2.2.3
-  - 2.3.0
   - 2.5.1
   - 2.6.3
+  - 2.7.1
 before_install: gem install bundler -v '1.17.3'
 install: bundle _1.17.3_ install
 script: bundle _1.17.3_ exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.5.1
-  - 2.6.3
-  - 2.7.1
-before_install: gem install bundler -v '1.17.3'
-install: bundle _1.17.3_ install
-script: bundle _1.17.3_ exec rake

--- a/lib/rest_client/jogger/response.rb
+++ b/lib/rest_client/jogger/response.rb
@@ -14,7 +14,7 @@ module RestClient
 
       def response_params(opts = {})
         response_headers = opts[:response].try(:headers) || {}
-        response_body = opts[:response].try(:body).to_s.force_encoding('UTF-8')
+        response_body = opts[:response].try(:body).to_s.dup.force_encoding('UTF-8')
         {
           exception: opts[:exception],
           response_headers: filtered_headers(response_headers),

--- a/lib/rest_client/jogger/version.rb
+++ b/lib/rest_client/jogger/version.rb
@@ -2,6 +2,6 @@
 
 module RestClient
   module Jogger
-    VERSION = '1.2.1'.freeze
+    VERSION = '1.2.2'
   end
 end

--- a/rest-client-jogger.gemspec
+++ b/rest-client-jogger.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'tilt'
   spec.add_dependency 'tilt-jbuilder'
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.2"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-json_expectations"


### PR DESCRIPTION
* Ruby 2.7 makes the code `nil.to_s` return a frozen string [1]
* When we try to use `force_encoding` on the string returned if
  a response body is empty, we end up trying to mutate the underlying
  frozen string and get a `FrozenError`. For now, an easy fix
  is to `dup` the response body string prior to forcing the encoding.

[1]: https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/18933