### PR TITLE
Normalize Header Keys

### DIFF
--- a/lib/rest_client/jogger/action.rb
+++ b/lib/rest_client/jogger/action.rb
@@ -51,7 +51,8 @@ module RestClient
       end
 
       def filter_class(headers = {})
-        content_type = headers.fetch(:content_type) { 'application/json' }
+        normalized_headers = headers.transform_keys { |k| k.to_s.downcase.tr('-', '_') }
+        content_type = normalized_headers.fetch('content_type') { 'application/json' }
         RestClient::Jogger::Filters::Base.filter_class(content_type)
       end
 

--- a/lib/rest_client/jogger/version.rb
+++ b/lib/rest_client/jogger/version.rb
@@ -2,6 +2,6 @@
 
 module RestClient
   module Jogger
-    VERSION = '1.2.2'
+    VERSION = '1.3.0'
   end
 end


### PR DESCRIPTION
* We use the `content-type` header to determine what filter class
  we need to use to scrub sensitive data. Previously, we didn't
  normalize header keys (the IETF spec mandates that headers are
  case-insensitive fields) when determining the content type of the
  payload.
* Normalize all header key values to a downcased, underscored string
  so that we are able to correctly determine the filter class that
  is required.

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/19614